### PR TITLE
buildkit-daemonless supports rootless

### DIFF
--- a/task/buildkit-daemonless/0.2/README.md
+++ b/task/buildkit-daemonless/0.2/README.md
@@ -1,0 +1,42 @@
+# BuildKit (Daemonless)
+
+This Task builds source into a container image using [Moby BuildKit](https://github.com/moby/buildkit).
+
+This `buildkit-daemonless` Task is similar to [`buildkit`](../../buildkit) but does not need creating `Secret`, `Deployment`, and `Service` resources for setting up the `buildkitd` daemon cluster.
+
+|                  | `buildkit`     | `buildkit-daemonless`|
+|------------------|----------------|----------------------|
+|Difficulty        | Hard           | Easy                 |
+|Supports Rootless | Yes            | Yes                  |
+|Cache             | Registry+Local | Registry             |
+
+## Install
+
+```console
+$ kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/buildkit-daemonless/0.2/buildkit-daemonless.yaml
+task.tekton.dev/buildkit-daemonless created
+```
+
+## Parameters
+
+* **IMAGE**: The name (reference) of the image to build.
+* **DOCKERFILE**: The path to the `Dockerfile` to execute (_default:_  `Dockerfile`)
+* **BUILDKIT_IMAGE**: BuildKit image (_default:_`moby/buildkit:vX.Y.Z-rootless@sha256:...`)
+
+## Workspaces
+
+* **source**: A [Workspace](https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md) containing the source to build.
+* **dockerconfig**: An optional [Workspace](https://github.com/tektoncd/pipeline/blob/master/docs/workspaces.md) containing a Docker `config.json`
+
+## Authentication to a Container Registry
+Buildkit builds an image and pushes it to the destination defined as a parameter.
+In order to properly authenticate to the remote container registry, it needs to
+have the proper credentials. This can achieved by using a workspace that contains
+the docker `config.json`.
+
+When using a workspace, the workspace shall be bound to a secret that embeds the
+configuration file in a key called `config.json`.
+
+## Platforms
+
+The Task can be run on `linux/amd64` platform.

--- a/task/buildkit-daemonless/0.2/buildkit-daemonless.yaml
+++ b/task/buildkit-daemonless/0.2/buildkit-daemonless.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildkit-daemonless
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/categories: Image Build
+    tekton.dev/tags: image-build
+    tekton.dev/displayName: "buildkit daemonless"
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: >-
+    This Task builds source into a container image using Moby BuildKit.
+
+    This buildkit-daemonless Task is similar to buildkit but does not need
+    creating Secret, Deployment, and Service resources for setting up the
+    buildkitd daemon cluster.
+
+  params:
+  - name: IMAGE
+    description: Name (reference) of the image to build
+  - name: DOCKERFILE
+    description: The name of the Dockerfile
+    default: "Dockerfile"
+  - name: BUILDKIT_IMAGE
+    description: The name of the BuildKit image
+    default: "docker.io/moby/buildkit:v0.9.3-rootless@sha256:d877f877f7411804fefaf90071464913130f8d34fe5797ac2f7164ddf816d27c"
+  workspaces:
+  - name: source
+  - name: dockerconfig
+    optional: true
+    mountPath: /home/user/.docker
+  steps:
+  - name: build-and-push
+    image: $(params.BUILDKIT_IMAGE)
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    env:
+    - name: BUILDKITD_FLAGS
+      value: --oci-worker-no-process-sandbox
+    command: ["buildctl-daemonless.sh", "--debug",
+              "build",
+              "--progress=plain",
+              "--frontend=dockerfile.v0",
+              "--opt", "filename=$(params.DOCKERFILE)",
+              "--local", "context=.", "--local", "dockerfile=.",
+              "--output", "type=image,name=$(params.IMAGE),push=true",
+              "--export-cache", "type=inline",
+              "--import-cache", "type=registry,ref=$(params.IMAGE)"]

--- a/task/buildkit-daemonless/0.2/tests/pre-apply-task-hook.sh
+++ b/task/buildkit-daemonless/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+add_sidecar_registry ${TMPF}
+add_task git-clone latest

--- a/task/buildkit-daemonless/0.2/tests/resources.yaml
+++ b/task/buildkit-daemonless/0.2/tests/resources.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: buildkit-daemonless-source-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi

--- a/task/buildkit-daemonless/0.2/tests/run.yaml
+++ b/task/buildkit-daemonless/0.2/tests/run.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: buildkit-daemonless-test-pipeline
+spec:
+  workspaces:
+  - name: shared-workspace
+  params:
+  - name: image
+    description: reference of the image to build
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    workspaces:
+    - name: output
+      workspace: shared-workspace
+    params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: subdirectory
+      value: ""
+    - name: deleteExisting
+      value: "true"
+  - name: buildkit-daemonless
+    taskRef:
+      name: buildkit-daemonless
+    runAfter:
+    - fetch-repository
+    workspaces:
+    - name: source
+      workspace: shared-workspace
+    params:
+    - name: IMAGE
+      value: $(params.image)
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: buildkit-daemonless-pipeline-run
+spec:
+  pipelineRef:
+    name: buildkit-daemonless-test-pipeline
+  params:
+  - name: image
+    value: localhost:5000/buildkit-daemonless-nocode
+  workspaces:
+  - name: shared-workspace
+    persistentvolumeclaim:
+      claimName: buildkit-daemonless-source-pvc


### PR DESCRIPTION
# Changes

* Supported rootless of buildkit-daemonless.
* Replaced PipelineResource (because of [deprecated](https://github.com/tektoncd/community/blob/main/teps/0074-deprecate-pipelineresources.md))
* Supported authentication via workspace

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Follows the [authoring recommendations](https://github.com/tektoncd/catalog/blob/main/recommendations.md)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality of task changed or new task added)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Complies with [Catalog Organization TEP][TEP], see [example]. **Note** [An issue has been filed to automate this validation][validation]
  - [ ] File path follows  `<kind>/<name>/<version>/name.yaml`
  - [ ] Has `README.md` at `<kind>/<name>/<version>/README.md`
  - [ ] Has mandatory `metadata.labels` - `app.kubernetes.io/version` the same as the `<version>` of the resource
  - [ ] Has mandatory `metadata.annotations` `tekton.dev/pipelines.minVersion`
  - [ ] mandatory `spec.description` follows the convention

          ```

          spec:
            description: >-
              one line summary of the resource

              Paragraph(s) to describe the resource.
          ```

_See [the contribution guide](https://github.com/tektoncd/catalog/blob/master/CONTRIBUTING.md)
for more details._

---

[TEP]: https://github.com/tektoncd/community/blob/master/teps/0003-tekton-catalog-organization.md
[example]: https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.1
[validation]:  https://github.com/tektoncd/catalog/issues/413
